### PR TITLE
Ensure listeners are destroyed in willDestroy

### DIFF
--- a/addon/components/confidentiality-sidebar-widget.js
+++ b/addon/components/confidentiality-sidebar-widget.js
@@ -9,9 +9,12 @@ export default class ConfidentialitySidebarWidget extends Component {
 
   constructor(parent, args) {
     super(parent, args);
-    this.args.controller.addTransactionStepListener(this.update.bind(this));
-    // const marks = this.controller.getMarksFor('confidentiality-mark');
-    // this.confidentialMarks = marks;
+    this.controller.addTransactionStepListener(this.update);
+  }
+
+  willDestroy() {
+    this.controller.removeTransactionStepListener(this.update);
+    super.willDestroy();
   }
 
   get controller() {
@@ -22,12 +25,12 @@ export default class ConfidentialitySidebarWidget extends Component {
     return steps.some((step) => step.type === 'operation-step');
   }
 
-  update(transaction) {
+  update = (transaction) => {
     const marks = transaction
       .getMarksManager()
       .getVisualMarkGroupsByMarkName('confidentiality-mark');
     this.confidentialMarkGroups = marks;
-  }
+  };
 
   @action
   removeConfidentialMarkGroup(markGroup) {

--- a/addon/components/confidentiality-toolbar-widget.js
+++ b/addon/components/confidentiality-toolbar-widget.js
@@ -8,7 +8,12 @@ export default class ConfidentialityToolbarWidget extends Component {
 
   constructor(parent, args) {
     super(parent, args);
-    this.args.controller.addTransactionStepListener(this.update.bind(this));
+    this.controller.addTransactionStepListener(this.update);
+  }
+
+  willDestroy() {
+    this.controller.removeTransactionStepListener(this.update);
+    super.willDestroy();
   }
 
   get controller() {
@@ -21,14 +26,14 @@ export default class ConfidentialityToolbarWidget extends Component {
     );
   }
 
-  update(transaction, steps) {
+  update = (transaction, steps) => {
     const { currentSelection: selection } = transaction;
     if (this.modifiesSelection(steps)) {
       this.selectedText = selection.lastRange.getTextContent();
       this.enabled =
         !selection.isCollapsed && !selection.hasMark('confidentiality-mark');
     }
-  }
+  };
 
   @action
   toggleMark() {


### PR DESCRIPTION
If this plugin would be dynamically disabled, it is important that its listeners are destroyed.